### PR TITLE
Update analytics data and migrate server to ES modules

### DIFF
--- a/analytics_data.json
+++ b/analytics_data.json
@@ -90,12 +90,19 @@
       "page": "/",
       "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15",
       "ip": "::ffff:127.0.0.1"
+    },
+    {
+      "timestamp": "2025-08-21T11:08:52.895Z",
+      "type": "page_view",
+      "page": "/",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+      "ip": "::ffff:127.0.0.1"
     }
   ],
   "sessionData": {
     "totalSessions": 0,
     "uniqueVisitors": 0,
-    "pageViews": 13,
-    "lastUpdated": "2025-08-21T11:08:45.059Z"
+    "pageViews": 14,
+    "lastUpdated": "2025-08-21T11:08:52.895Z"
   }
 }

--- a/analytics_data.json
+++ b/analytics_data.json
@@ -62,12 +62,33 @@
       "page": "/",
       "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
       "ip": "::ffff:127.0.0.1"
+    },
+    {
+      "timestamp": "2025-08-21T11:07:53.088Z",
+      "type": "page_view",
+      "page": "/",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15",
+      "ip": "::ffff:127.0.0.1"
+    },
+    {
+      "timestamp": "2025-08-21T11:08:02.363Z",
+      "type": "page_view",
+      "page": "/",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+      "ip": "::ffff:127.0.0.1"
+    },
+    {
+      "timestamp": "2025-08-21T11:08:07.774Z",
+      "type": "page_view",
+      "page": "/",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+      "ip": "::ffff:127.0.0.1"
     }
   ],
   "sessionData": {
     "totalSessions": 0,
     "uniqueVisitors": 0,
-    "pageViews": 9,
-    "lastUpdated": "2025-08-21T11:00:16.005Z"
+    "pageViews": 12,
+    "lastUpdated": "2025-08-21T11:08:07.774Z"
   }
 }

--- a/analytics_data.json
+++ b/analytics_data.json
@@ -83,12 +83,19 @@
       "page": "/",
       "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
       "ip": "::ffff:127.0.0.1"
+    },
+    {
+      "timestamp": "2025-08-21T11:08:45.059Z",
+      "type": "page_view",
+      "page": "/",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15",
+      "ip": "::ffff:127.0.0.1"
     }
   ],
   "sessionData": {
     "totalSessions": 0,
     "uniqueVisitors": 0,
-    "pageViews": 12,
-    "lastUpdated": "2025-08-21T11:08:07.774Z"
+    "pageViews": 13,
+    "lastUpdated": "2025-08-21T11:08:45.059Z"
   }
 }

--- a/production-server.js
+++ b/production-server.js
@@ -1,6 +1,10 @@
-const express = require("express");
-const path = require("path");
-const cors = require("cors");
+import express from "express";
+import path from "path";
+import cors from "cors";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 const PORT = process.env.PORT || 8080;
@@ -53,4 +57,4 @@ app.listen(PORT, "0.0.0.0", () => {
   console.log(`🌍 Environment: ${process.env.NODE_ENV || "production"}`);
 });
 
-module.exports = app;
+export default app;


### PR DESCRIPTION
## Purpose
Based on the build logs showing successful production deployment, this update captures new analytics data from recent page views and modernizes the server code by migrating from CommonJS to ES modules.

## Code changes
- **Analytics data**: Added 5 new page view entries to `analytics_data.json` with timestamps from 2025-08-21T11:07-11:08, updating total page views from 9 to 14
- **Server modernization**: Converted `production-server.js` from CommonJS to ES modules:
  - Changed `require()` statements to `import` statements
  - Added `fileURLToPath` and `__dirname` setup for ES module compatibility
  - Changed `module.exports` to `export default`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cd1f98007b5a4afe98a38dc1097556a9/aura-lab)

👀 [Preview Link](https://cd1f98007b5a4afe98a38dc1097556a9-aura-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cd1f98007b5a4afe98a38dc1097556a9</projectId>-->
<!--<branchName>aura-lab</branchName>-->